### PR TITLE
Strict integer parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Gemfile.lock

--- a/lib/attr_typed.rb
+++ b/lib/attr_typed.rb
@@ -17,7 +17,7 @@ require "date"
 #
 module AttrTyped
   ALLOWED_TYPES ||= [
-    :string, :money, :time, :big_decimal, :date, :integer, :boolean, :date_time
+    :string, :money, :time, :big_decimal, :date, :integer, :strict_integer, :boolean, :date_time
   ]
 
   def self.included(klass)
@@ -45,6 +45,14 @@ module AttrTyped
 
   def parse_integer(value)
     value.to_i
+  end
+
+  def parse_strict_integer(value)
+    return value if value.is_a?(Integer)
+    # remove leading zeroes to ensure Integer converts via base 10
+    Integer(value.to_s.gsub(/^0+/,''))
+  rescue ArgumentError
+    nil
   end
 
   def parse_date(value)

--- a/lib/attr_typed.rb
+++ b/lib/attr_typed.rb
@@ -68,12 +68,16 @@ module AttrTyped
     return value.to_d if value.is_a?(Float)
 
     BigDecimal.new(value)
+  rescue ArgumentError
+    BigDecimal.new(0)
   end
 
   def parse_money(value)
     return value if value.is_a?(Money)
 
     Monetize.from_bigdecimal(BigDecimal.new(value.to_s))
+  rescue ArgumentError
+    Money.new(0)
   end
 
   def parse_time(value)

--- a/lib/attr_typed/version.rb
+++ b/lib/attr_typed/version.rb
@@ -1,3 +1,3 @@
 module AttrTyped
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end

--- a/spec/attr_typed_spec.rb
+++ b/spec/attr_typed_spec.rb
@@ -186,6 +186,65 @@ describe AttrTyped do
       end
     end
 
+    context "strict integer" do
+      let(:human) { TypeParsingTest.new }
+
+      before do
+        TypeParsingTest.attr_typed(identity_number: :strict_integer)
+        human.identity_number = identity_number
+      end
+
+      subject { human.identity_number }
+
+      context "integer value" do
+        let(:identity_number) { 100100110 }
+
+        it { is_expected.to eq(100100110) }
+      end
+
+      context "string value" do
+        let(:identity_number) { "2151812" }
+
+        it { is_expected.to eq(2151812) }
+      end
+
+      context "with nil" do
+        let(:identity_number) { nil }
+
+        it { is_expected.to be_nil }
+      end
+
+      context "with leading zeroes" do
+        let(:identity_number) { '00001234' }
+
+        it { is_expected.to eq(1234) }
+      end
+
+      context "with characters" do
+        let(:identity_number) { '00012345ABC65' }
+
+        it { is_expected.to be_nil }
+      end
+
+      context "with trailing space" do
+        let(:identity_number) { '123456 ' }
+
+        it { is_expected.to  eq(123456) }
+      end
+
+      context "with leading space" do
+        let(:identity_number) { ' 123456' }
+
+        it { is_expected.to eq(123456) }
+      end
+
+      context "with period" do
+        let(:identity_number) { '12345.' }
+
+        it { is_expected.to be_nil }
+      end
+    end
+
     context "money" do
       let(:human) { TypeParsingTest.new }
 


### PR DESCRIPTION
`to_i` for direct integer parsing is generally ok. 

But this has unexpected outcomes in some scenarios, for instance `'00012345ABC67'.to_i` becomes `12345` - this should be an invalid integer when we're checking from dirty inputs.

Now `:strict_integer` will be nil in these cases but correctly convert in all others, see test cases for all examples.