### PR TITLE
Bump rake to non-vulnerable version

### DIFF
--- a/attr_typed.gemspec
+++ b/attr_typed.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'monetize', '>= 1.0.0'
 
-  spec.add_development_dependency "bundler", "~> 1.10"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "bundler", "~> 2.1.4"
+  spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "rspec"
 end


### PR DESCRIPTION
This is probably pretty low priority, but I'd like to silence the
github security advisory emails so they're out of the ordinary and not
just filtered out subconciously.