### PR TITLE
Update deprecated BigDecimal call

### DIFF
--- a/attr_typed.gemspec
+++ b/attr_typed.gemspec
@@ -13,6 +13,8 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/Ferocia/attr_typed"
   spec.license       = "MIT"
 
+  spec.required_ruby_version = '>= 2.4.0'
+
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.require_paths = ["lib"]
 

--- a/lib/attr_typed.rb
+++ b/lib/attr_typed.rb
@@ -75,15 +75,15 @@ module AttrTyped
     return value if value.is_a?(BigDecimal)
     return value.to_d if value.is_a?(Float)
 
-    BigDecimal.new(value)
+    BigDecimal(value)
   rescue ArgumentError
-    BigDecimal.new(0)
+    BigDecimal(0)
   end
 
   def parse_money(value)
     return value if value.is_a?(Money)
 
-    Monetize.from_bigdecimal(BigDecimal.new(value.to_s))
+    Monetize.from_bigdecimal(BigDecimal(value.to_s))
   rescue ArgumentError
     Money.new(0)
   end


### PR DESCRIPTION
Fixes `warning: BigDecimal.new is deprecated; use BigDecimal()` warnings.